### PR TITLE
Sort by date and type, not BID

### DIFF
--- a/app/src/main/java/com/el1t/iolite/adapter/BlockListAdapter.java
+++ b/app/src/main/java/com/el1t/iolite/adapter/BlockListAdapter.java
@@ -230,13 +230,17 @@ public class BlockListAdapter extends ArrayAdapter<EighthBlockItem>
 		sort();
 	}
 
-	// Sort by BID (which also happens to sort by date)
+	// Sort by block date and type
 	private class BIDSortComp implements Comparator<EighthBlockItem>
 	{
 		@Override
 		public int compare(EighthBlockItem e1, EighthBlockItem e2) {
-			// Double, because Integer does not have compare prior to Java 7
-			return Double.compare(e1.getBID(), e2.getBID());
+			int cmp = e1.getDate().compareTo(e2.getDate());
+			if (cmp != 0) {
+				return cmp;
+			} else {
+				return e1.getBlock().compareTo(e2.getBlock());
+			}
 		}
 	}
 }


### PR DESCRIPTION
The special AMC F block next Tuesday, February 3, is currently sorted below all other blocks. This is due to sorting by BID, which sorts close to, but not exactly, chronologically, which I assume is the intended behavior. Hopefully this fixes it!
I haven't tested the code so apologies if it doesn't work. And the class name `BIDSortComp` should probably be changed as well.